### PR TITLE
Use pretty URLs in docs.snapcraft.io

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -1,4 +1,3 @@
-t/(?P<path>.*)/?: /{path}
 build-snaps/?: /the-snap-format/698
 build-snaps/build-for-another-arch/?: /building-the-snap/6800
 build-snaps/build-on-lxd-docker/?: /building-the-snap-on-docker/6757

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # App dependencies
 talisker[gunicorn]==0.14.3
 Flask==1.0.2
-canonicalwebteam.discourse_docs==0.1.1
+canonicalwebteam.discourse-docs==0.2.0
 canonicalwebteam.http==0.1.6
 canonicalwebteam.yaml_responses[flask]==1.1.0
 

--- a/templates/404.html
+++ b/templates/404.html
@@ -6,7 +6,7 @@
   <aside class="l-docs-sidebar" id="navigation">
     <i class="p-sidenav__toggle p-icon--menu u-hide--medium u-hide--large"></i>
     <nav class="p-sidenav__body u-hide--small">
-      {{ nav_html | safe }}
+      {{ navigation | safe }}
     </nav>
   </aside>
 

--- a/templates/410.html
+++ b/templates/410.html
@@ -6,7 +6,7 @@
   <aside class="l-docs-sidebar" id="navigation">
     <i class="p-sidenav__toggle p-icon--menu u-hide--medium u-hide--large"></i>
     <nav class="p-sidenav__body u-hide--small">
-      {{ nav_html | safe }}
+      {{ navigation | safe }}
     </nav>
   </aside>
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -7,9 +7,8 @@
         <meta name="viewport" content="width=device-width, initial-scale=1">
       {% endblock %}
 
-      {% block title %}
-        <title>{% if title %}{{ title }} - {% endif %}Documentation for snaps: Universal Linux packages</title>
-      {% endblock %}
+      <title>{% if self.title() %}{% block title %}{% endblock %} - {% endif %}Documentation for snaps: Universal Linux packages</title>
+
       <!-- Google Tag Manager -->
       <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
       new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],

--- a/templates/document.html
+++ b/templates/document.html
@@ -4,26 +4,26 @@
   <aside class="l-docs-sidebar" id="navigation">
     <i class="p-sidenav__toggle p-icon--menu u-hide u-show--small"></i>
     <nav class="p-sidenav__body u-hide--small">
-      {{ nav_html | safe }}
+      {{ navigation | safe }}
     </nav>
   </aside>
 
   <main class="l-docs-content" id="main-content">
     <div class="p-strip--light is-shallow docs-title">
       <div class="l-docs-row">
-        <h1 class="u-no-margin--bottom docs-title__heading">{{ title }}</h1>
+        <h1 class="u-no-margin--bottom docs-title__heading">{{ document.title }}</h1>
       </div>
     </div>
 
     <div class="p-strip is-shallow">
       <div class="l-docs-row">
-        {{ body_html | safe }}
+        {{ document.body_html | safe }}
       </div>
 
       <div class="l-docs-row" style="padding-top: 3rem">
         <div class="p-notification--information">
           <p class="p-notification__response">
-            Last updated {{ updated }}. <a href="{{ forum_link }}">Help improve this document in the forum</a>.
+            Last updated {{ document.updated }}. <a href="{{ forum_url }}{{ document.topic_path }}">Help improve this document in the forum</a>.
           </p>
         </div>
       </div>

--- a/templates/search.html
+++ b/templates/search.html
@@ -5,9 +5,7 @@
     <meta name="robots" content="noindex" />
 {% endblock %}
 
-{% block title %}
-    <title>Search results{% if query %} for "{{query}}"{% endif %} | Documentation for snaps: Universal Linux packages</title>
-{% endblock %}
+{% block title %}Search results{% if query %} for "{{query}}"{% endif %}{% endblock %}
 
 {% block body %}
   <div class="p-strip is-shallow u-no-padding--bottom">

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -71,9 +71,7 @@ def page_not_found(e):
     index = parse_index(discourse_api.get_topic(discourse_index_id))
 
     return (
-        flask.render_template(
-            "404.html", navigation=index["navigation"]
-        ),
+        flask.render_template("404.html", navigation=index["navigation"]),
         404,
     )
 

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -11,7 +11,7 @@ from werkzeug.debug import DebuggedApplication
 import talisker.flask
 import talisker.logs
 from canonicalwebteam.discourse_docs import DiscourseAPI, DiscourseDocs
-from canonicalwebteam.discourse_docs.models import NavigationParseError
+from canonicalwebteam.discourse_docs.parsers import parse_index
 from canonicalwebteam.yaml_responses.flask_helpers import (
     prepare_deleted,
     prepare_redirects,
@@ -37,30 +37,28 @@ app.wsgi_app = ProxyFix(app.wsgi_app)
 talisker.flask.register(app)
 talisker.logs.set_global_extra({"service": "docs.snapcraft.io"})
 
-discourse_api = DiscourseAPI(
-    base_url="https://forum.snapcraft.io/",
-    frontpage_id=3781,  # The "Snap Documentation" topic
-    category_id=15,  # The "doc" category
-)
-DiscourseDocs().init_app(
-    app=app,
-    model=discourse_api,
-    url_prefix="/",
+discourse_index_id = 11127
+
+discourse_api = DiscourseAPI(base_url="https://forum.snapcraft.io/")
+discourse_docs = DiscourseDocs(
+    api=discourse_api,
+    index_topic_id=discourse_index_id,
+    category_id=15,
     document_template="document.html",
 )
+discourse_docs.init_app(app, url_prefix="/")
 
 # Parse redirects.yaml and permanent-redirects.yaml
 app.before_request(prepare_redirects())
 
 
 def deleted_callback(context):
-    try:
-        frontpage, nav_html = discourse_api.parse_frontpage()
-    except NavigationParseError as nav_error:
-        nav_html = f"<p>{str(nav_error)}</p>"
+    index = parse_index(discourse_api.get_topic(discourse_index_id))
 
     return (
-        flask.render_template("410.html", nav_html=nav_html, **context),
+        flask.render_template(
+            "410.html", navigation=index["navigation"], **context
+        ),
         410,
     )
 
@@ -70,12 +68,14 @@ app.before_request(prepare_deleted(view_callback=deleted_callback))
 
 @app.errorhandler(404)
 def page_not_found(e):
-    try:
-        frontpage, nav_html = discourse_api.parse_frontpage()
-    except NavigationParseError as nav_error:
-        nav_html = f"<p>{str(nav_error)}</p>"
+    index = parse_index(discourse_api.get_topic(discourse_index_id))
 
-    return flask.render_template("404.html", nav_html=nav_html), 404
+    return (
+        flask.render_template(
+            "404.html", navigation=index["navigation"]
+        ),
+        404,
+    )
 
 
 @app.errorhandler(410)


### PR DESCRIPTION
This makes use of the new changes in `v0.2.0` of [canonicalwebteam.discourse-docs](https://github.com/canonical-web-and-design/canonicalwebteam.discourse-docs), to bring crafted URLs to documentation pages. So the changes are:

- The homepage now appears at `/` (rather than `/snap-documentation/3781`)
- URLs in the left navigation have been replaced with their "pretty" versions
- If you visit a topic URL, e.g. `/t/snap-confinement/6233`, you should end up at the pretty URL, e.g. `/snap-confinement`
- Topics that don't have pretty URLs defined will now be shown at `/t/{slug}/{id}` rather than `/{slug}/{id}`, because the solution to making this URL prettier should always be to create a proper URL mapping

QA
--

`./run`

- See the homepage appears at http://0.0.0.0:8030/, and that http://0.0.0.0:8030/snap-docs/11127, http://0.0.0.0:8030/t/snap-docs/11127, http://0.0.0.0:8030/11127 all redirect there
- Check all the URLs in the left navigation are "pretty" (as in `/{something}` rather than `/t/{something}/{id}`)
- Check that if you go to a topic URL, it redirects to the pretty one - e.g. http://0.0.0.0:8030/t/getting-started/3876, http://0.0.0.0:8030/getting-started/3876 and http://0.0.0.0:8030/3876 all redirect to http://0.0.0.0:8030/getting-started