### PR TITLE
Bump canonicalwebteam.discourse-docs to 0.4.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # App dependencies
 talisker[gunicorn]==0.14.3
 Flask==1.0.2
-canonicalwebteam.discourse-docs==0.3.0
+canonicalwebteam.discourse-docs==0.4.0
 canonicalwebteam.http==0.1.6
 canonicalwebteam.yaml_responses[flask]==1.1.0
 


### PR DESCRIPTION
## Done
Bumps the discourse extension to 0.4.0 so when you try to access topics
that do not belong to the docs category you are redirected to the forum.

## QA
- Go to `/11365` and make sure you are redirected to `https://forum.snapcraft.io/t/multipass-does-not-start-on-ubuntu-server-18-04/11365`

- Go to `/multipass-does-not-start-on-ubuntu-server-18-04/11365` and make sure you are redirected to `https://forum.snapcraft.io/t/multipass-does-not-start-on-ubuntu-server-18-04/11365`

- Go to `/t/multipass-does-not-start-on-ubuntu-server-18-04/11365` and make sure you are redirected to `https://forum.snapcraft.io/t/multipass-does-not-start-on-ubuntu-server-18-04/11365`

- Go to `/multipass-does-not-start-on-ubuntu-server-18-04` and make sure you see a 404
- Go to `/t/multipass-does-not-start-on-ubuntu-server-18-04` and make sure you see a 404

- Feel free to try with other topics and also double check all still works fine for the docs category topics.

Fixes #145 